### PR TITLE
fixed issue

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,6 @@
     "noEmitOnError": true,
     "resolveJsonModule": true
   },
-  "exclude": ["node_modules", "android", "ios", "lib", "types"]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "android", "ios", "lib", "types", "babel.config.js"]
 }


### PR DESCRIPTION
`include: ["src/**/*"]` → only compiles files inside src/.

`exclude: ["babel.config.js", ...] `→ prevents TS from treating non-source files as input.